### PR TITLE
Overload of CompositeC1WebPage.Function(...) to allow explicit FunctionContextContainer

### DIFF
--- a/Composite/AspNet/Razor/C1HtmlHelper.cs
+++ b/Composite/AspNet/Razor/C1HtmlHelper.cs
@@ -407,6 +407,7 @@ namespace Composite.AspNet.Razor
         /// </summary>
         /// <param name="name">Function name.</param>
         /// <returns></returns>
+        [Obsolete("Use Function method directly on the Razor page")]
         public IHtmlString Function(string name)
         {
             return Function(name, null);
@@ -418,6 +419,7 @@ namespace Composite.AspNet.Razor
         /// <param name="name">Function name.</param>
         /// <param name="parameters">The parameters.</param>
         /// <returns></returns>
+        [Obsolete("Use Function method directly on the Razor page")]
         public IHtmlString Function(string name, object parameters)
         {
             return Function(name, Functions.ObjectToDictionary(parameters));
@@ -429,6 +431,7 @@ namespace Composite.AspNet.Razor
         /// <param name="name">Function name.</param>
         /// <param name="parameters">The parameters.</param>
         /// <returns></returns>
+        [Obsolete("Use Function method directly on the Razor page")]
         public IHtmlString Function(string name, IDictionary<string, object> parameters)
         {
             return Function(name, parameters, new FunctionContextContainer());

--- a/Composite/AspNet/Razor/CompositeC1WebPage.cs
+++ b/Composite/AspNet/Razor/CompositeC1WebPage.cs
@@ -133,9 +133,20 @@ namespace Composite.AspNet.Razor
 		/// <returns></returns>
 		public IHtmlString Function(string name, IDictionary<string, object> parameters)
 		{
-            return Html.C1().Function(name, parameters, GetFunctionContext());
+            return Function(name, parameters, GetFunctionContext());
 		}
 
+        /// <summary>
+        /// Executes a C1 Function.
+        /// </summary>
+        /// <param name="name">Function name.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <param name="functionContextContainer">The FunctionContextContainer used to execute the function.</param>
+        /// <returns></returns>
+        public IHtmlString Function(string name, IDictionary<string, object> parameters, FunctionContextContainer functionContextContainer)
+        {
+            return Html.C1().Function(name, parameters, functionContextContainer);
+        }
 
         private FunctionContextContainer GetFunctionContext()
         {


### PR DESCRIPTION
Overload of CompositeC1WebPage.Function(...) to allow explicit FunctionContextContainer

Marking C1HtmlHelper.Function(...) that doesn't accept a FunctionContextContainer as obsolete, since they behave differently whether you pass one or not which isn't what would expect.

Related to [issue 191](https://github.com/Orckestra/CMS-Foundation/issues/191)
