### PR TITLE
Web.config cleanup

### DIFF
--- a/Website/DebugBuild.Web.config
+++ b/Website/DebugBuild.Web.config
@@ -1,11 +1,34 @@
 ﻿<configuration>
 	<!-- Hey Dev! Changing or removing existing elements in this file may cause functionality in C1 CMS to break -->
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-1.1.20.0" newVersion="1.1.20.0" />
+				<codeBase version="1.1.20.0" href="bin\ExtraDllVersion\System.Collections.Immutable.dll" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+	<system.codedom>
+		<compilers>
+			<compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=0.2.0.0, Culture=neutral" warningLevel="4" />
+			<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" compilerOptions="/optioninfer+" type="Microsoft.VisualBasic.VBCodeProvider, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+				<providerOption name="CompilerVersion" value="v4.0" />
+			</compiler>
+		</compilers>
+	</system.codedom>
+	<system.serviceModel>
+		<serviceHostingEnvironment multipleSiteBindingsEnabled="true" />
+	</system.serviceModel>
 	<system.web>
-		<trust level="Full" />
-		<globalization requestEncoding="utf-8" responseEncoding="utf-8" />
-		<customErrors mode="Off">
-			<error statusCode="404" redirect="Renderers/FileNotFoundHandler.ashx" />
-		</customErrors>
+		<authentication mode="Forms" />
+		<caching>
+			<outputCacheSettings>
+				<outputCacheProfiles>
+					<add name="C1Page" duration="0" varyByCustom="C1Page" varyByParam="*" />
+				</outputCacheProfiles>
+			</outputCacheSettings>
+		</caching>
 		<compilation debug="true" optimizeCompilations="false">
 			<assemblies>
 				<add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
@@ -20,53 +43,35 @@
 				<add extension=".cshtml" type="System.Web.WebPages.Razor.RazorBuildProvider, System.Web.WebPages.Razor" />
 			</buildProviders>
 		</compilation>
+		<customErrors mode="Off">
+			<error statusCode="404" redirect="Renderers/FileNotFoundHandler.ashx" />
+		</customErrors>
+		<globalization requestEncoding="utf-8" responseEncoding="utf-8" />
 		<httpRuntime targetFramework="4.6.1" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
 		<!-- colon removed from @requestPathInvalidCharacters -->
-		<xhtmlConformance mode="Strict" />
-		<trace enabled="false" traceMode="SortByTime" requestLimit="100" writeToDiagnosticsTrace="false" pageOutput="true" />
 		<pages clientIDMode="AutoID">
 			<controls>
 				<add tagPrefix="f" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Functions" assembly="Composite" />
 				<add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />
 			</controls>
 		</pages>
-		<!--  IIS6 & IIS7 Classic mode -->
-		<httpModules>
-			<add name="ApplicationOfflineCheck" type="Composite.Core.Application.ApplicationOfflineCheckHttpModule, Composite" />
-			<add name="AjaxResponseHandler" type="Composite.Core.WebClient.Ajax.AjaxResponseHttpModule, Composite" />
-			<add name="CompositeAdministrativeResponseFilter" type="Composite.Core.WebClient.HttpModules.AdministrativeResponseFilterHttpModule, Composite" />
-			<add name="CompositeAdministrativeAuthorization" type="Composite.Core.WebClient.HttpModules.AdministrativeAuthorizationHttpModule, Composite" />
-			<add name="CompositeRequestInterceptor" type="Composite.Core.WebClient.Renderings.RequestInterceptorHttpModule, Composite" />
-			<add name="CompositeAdministrativeDataScopeSetter" type="Composite.Core.WebClient.HttpModules.AdministrativeDataScopeSetterHttpModule, Composite" />
-			<add name="CompositeAdministrativeCultureSetter" type="Composite.Core.WebClient.HttpModules.AdministrativeCultureSetterHttpModule, Composite" />
-		</httpModules>
-		<caching>
-			<outputCacheSettings>
-				<outputCacheProfiles>
-					<add name="C1Page" duration="0" varyByCustom="C1Page" varyByParam="*" />
-				</outputCacheProfiles>
-			</outputCacheSettings>
-		</caching>
-		<httpHandlers>
-			<add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
-		</httpHandlers>
 		<siteMap defaultProvider="CompositeC1">
 			<providers>
 				<add name="CompositeC1" type="Composite.AspNet.CmsPageSiteMapProvider, Composite" />
 			</providers>
 		</siteMap>
+		<trace enabled="false" traceMode="SortByTime" requestLimit="100" writeToDiagnosticsTrace="false" pageOutput="true" />
+		<trust level="Full" />
+		<xhtmlConformance mode="Strict" />
 	</system.web>
-	<system.codedom>
-		<compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=0.2.0.0, Culture=neutral" warningLevel="4" />
-			<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" compilerOptions="/optioninfer+" type="Microsoft.VisualBasic.VBCodeProvider, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-				<providerOption name="CompilerVersion" value="v4.0" />
-			</compiler>
-		</compilers>
-	</system.codedom>
 	<!-- IIS7 Intergrated mode configuration -->
 	<system.webServer>
-		<validation validateIntegratedModeConfiguration="false" />
+		<handlers>
+			<add name="SiteMap" verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
+			<add name="Wildcard ASP.NET mapping" preCondition="classicMode,runtimeVersionv4.0,bitness32" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
+			<add name="Wildcard ASP.NET mapping (x64)" preCondition="classicMode,runtimeVersionv4.0,bitness64" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
+			<add name="UrlRoutingHandler" preCondition="integratedMode" verb="*" path="UrlRouting.axd" type="System.Web.HttpForbiddenHandler, System.Web, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+		</handlers>
 		<modules runAllManagedModulesForAllRequests="true">
 			<remove name="UrlRoutingModule" />
 			<add name="ApplicationOfflineCheck" type="Composite.Core.Application.ApplicationOfflineCheckHttpModule, Composite" />
@@ -78,29 +83,12 @@
 			<add name="CompositeAdministrativeCultureSetter" type="Composite.Core.WebClient.HttpModules.AdministrativeCultureSetterHttpModule, Composite" />
 			<add name="UrlRoutingModule" type="System.Web.Routing.UrlRoutingModule, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 		</modules>
-		<handlers>
-			<add name="SiteMap" verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
-			<add name="Wildcard ASP.NET mapping" preCondition="classicMode,runtimeVersionv4.0,bitness32" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
-			<add name="Wildcard ASP.NET mapping (x64)" preCondition="classicMode,runtimeVersionv4.0,bitness64" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
-			<add name="UrlRoutingHandler" preCondition="integratedMode" verb="*" path="UrlRouting.axd" type="System.Web.HttpForbiddenHandler, System.Web, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-		</handlers>
 		<staticContent>
 			<clientCache cacheControlMode="NoControl" />
 			<remove fileExtension=".json" />
 			<mimeMap fileExtension=".json" mimeType="application/json" />
 		</staticContent>
 		<urlCompression doDynamicCompression="true" doStaticCompression="true" dynamicCompressionBeforeCache="true" />
+		<validation validateIntegratedModeConfiguration="false" />
 	</system.webServer>
-	<system.serviceModel>
-		<serviceHostingEnvironment multipleSiteBindingsEnabled="true" />
-	</system.serviceModel>
-	<runtime>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-		  <dependentAssembly>
-			<assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-			<codeBase version="1.1.20.0" href="bin\ExtraDllVersion\System.Collections.Immutable.dll" />
-			<bindingRedirect oldVersion="0.0.0.0-1.1.20.0" newVersion="1.1.20.0" />
-		  </dependentAssembly>
-		</assemblyBinding>
-	</runtime>
 </configuration>

--- a/Website/ReleaseBuild.Web.config
+++ b/Website/ReleaseBuild.Web.config
@@ -1,11 +1,34 @@
 ﻿<configuration>
 	<!-- Hey Dev! Changing or removing existing elements in this file may cause functionality in C1 CMS to break -->
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-1.1.20.0" newVersion="1.1.20.0" />
+				<codeBase version="1.1.20.0" href="bin\ExtraDllVersion\System.Collections.Immutable.dll" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+	<system.codedom>
+		<compilers>
+			<compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=0.2.0.0, Culture=neutral" warningLevel="4" />
+			<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" compilerOptions="/optioninfer+" type="Microsoft.VisualBasic.VBCodeProvider, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+				<providerOption name="CompilerVersion" value="v4.0" />
+			</compiler>
+		</compilers>
+	</system.codedom>
+	<system.serviceModel>
+		<serviceHostingEnvironment multipleSiteBindingsEnabled="true" />
+	</system.serviceModel>
 	<system.web>
-		<trust level="Full" />
-		<globalization requestEncoding="utf-8" responseEncoding="utf-8" />
-		<customErrors mode="RemoteOnly">
-			<error statusCode="404" redirect="Renderers/FileNotFoundHandler.ashx" />
-		</customErrors>
+		<authentication mode="Forms" />
+		<caching>
+			<outputCacheSettings>
+				<outputCacheProfiles>
+					<add name="C1Page" duration="60" varyByCustom="C1Page" varyByParam="*" />
+				</outputCacheProfiles>
+			</outputCacheSettings>
+		</caching>
 		<compilation debug="false" optimizeCompilations="false">
 			<assemblies>
 				<add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
@@ -20,53 +43,35 @@
 				<add extension=".cshtml" type="System.Web.WebPages.Razor.RazorBuildProvider, System.Web.WebPages.Razor" />
 			</buildProviders>
 		</compilation>
-		<httpRuntime targetFramework="4.6.1" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" /> 
+		<customErrors mode="RemoteOnly">
+			<error statusCode="404" redirect="Renderers/FileNotFoundHandler.ashx" />
+		</customErrors>
+		<globalization requestEncoding="utf-8" responseEncoding="utf-8" />
+		<httpRuntime targetFramework="4.6.1" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
 		<!-- colon removed from @requestPathInvalidCharacters -->
-		<xhtmlConformance mode="Strict" />
-		<trace enabled="false" traceMode="SortByTime" requestLimit="100" writeToDiagnosticsTrace="false" pageOutput="true" />
 		<pages clientIDMode="AutoID">
 			<controls>
 				<add tagPrefix="f" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Functions" assembly="Composite" />
 				<add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />
 			</controls>
 		</pages>
-		<!--  IIS6 & IIS7 Classic mode -->
-		<httpModules>
-			<add name="ApplicationOfflineCheck" type="Composite.Core.Application.ApplicationOfflineCheckHttpModule, Composite" />
-			<add name="AjaxResponseHandler" type="Composite.Core.WebClient.Ajax.AjaxResponseHttpModule, Composite" />
-			<add name="CompositeAdministrativeResponseFilter" type="Composite.Core.WebClient.HttpModules.AdministrativeResponseFilterHttpModule, Composite" />
-			<add name="CompositeAdministrativeAuthorization" type="Composite.Core.WebClient.HttpModules.AdministrativeAuthorizationHttpModule, Composite" />
-			<add name="CompositeRequestInterceptor" type="Composite.Core.WebClient.Renderings.RequestInterceptorHttpModule, Composite" />
-			<add name="CompositeAdministrativeDataScopeSetter" type="Composite.Core.WebClient.HttpModules.AdministrativeDataScopeSetterHttpModule, Composite" />
-			<add name="CompositeAdministrativeCultureSetter" type="Composite.Core.WebClient.HttpModules.AdministrativeCultureSetterHttpModule, Composite" />
-		</httpModules>
-		<caching>
-			<outputCacheSettings>
-				<outputCacheProfiles>
-					<add name="C1Page" duration="60" varyByCustom="C1Page" varyByParam="*" />
-				</outputCacheProfiles>
-			</outputCacheSettings>
-		</caching>
-		<httpHandlers>
-			<add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
-		</httpHandlers>
 		<siteMap defaultProvider="CompositeC1">
 			<providers>
 				<add name="CompositeC1" type="Composite.AspNet.CmsPageSiteMapProvider, Composite" />
 			</providers>
 		</siteMap>
+		<trace enabled="false" traceMode="SortByTime" requestLimit="100" writeToDiagnosticsTrace="false" pageOutput="true" />
+		<trust level="Full" />
+		<xhtmlConformance mode="Strict" />
 	</system.web>
-	<system.codedom>
-		<compilers>
-			<compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=0.2.0.0, Culture=neutral" warningLevel="4" />
-			<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" compilerOptions="/optioninfer+" type="Microsoft.VisualBasic.VBCodeProvider, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-				<providerOption name="CompilerVersion" value="v4.0" />
-			</compiler>
-		</compilers>
-	</system.codedom>
 	<!-- IIS7 Intergrated mode configuration -->
 	<system.webServer>
-		<validation validateIntegratedModeConfiguration="false" />
+		<handlers>
+			<add name="SiteMap" verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
+			<add name="Wildcard ASP.NET mapping" preCondition="classicMode,runtimeVersionv4.0,bitness32" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
+			<add name="Wildcard ASP.NET mapping (x64)" preCondition="classicMode,runtimeVersionv4.0,bitness64" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
+			<add name="UrlRoutingHandler" preCondition="integratedMode" verb="*" path="UrlRouting.axd" type="System.Web.HttpForbiddenHandler, System.Web, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+		</handlers>
 		<modules runAllManagedModulesForAllRequests="true">
 			<remove name="UrlRoutingModule" />
 			<add name="ApplicationOfflineCheck" type="Composite.Core.Application.ApplicationOfflineCheckHttpModule, Composite" />
@@ -78,12 +83,6 @@
 			<add name="CompositeAdministrativeCultureSetter" type="Composite.Core.WebClient.HttpModules.AdministrativeCultureSetterHttpModule, Composite" />
 			<add name="UrlRoutingModule" type="System.Web.Routing.UrlRoutingModule, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 		</modules>
-		<handlers>
-			<add name="SiteMap" verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
-			<add name="Wildcard ASP.NET mapping" preCondition="classicMode,runtimeVersionv4.0,bitness32" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
-			<add name="Wildcard ASP.NET mapping (x64)" preCondition="classicMode,runtimeVersionv4.0,bitness64" path="*" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" resourceType="Unspecified" requireAccess="None" />
-			<add name="UrlRoutingHandler" preCondition="integratedMode" verb="*" path="UrlRouting.axd" type="System.Web.HttpForbiddenHandler, System.Web, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-		</handlers>
 		<staticContent>
 			<clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00" />
 			<remove fileExtension=".json" />
@@ -92,17 +91,6 @@
 			<mimeMap fileExtension=".scss" mimeType="text/css" />
 		</staticContent>
 		<urlCompression doDynamicCompression="true" doStaticCompression="true" dynamicCompressionBeforeCache="true" />
+		<validation validateIntegratedModeConfiguration="false" />
 	</system.webServer>
-	<system.serviceModel>
-		<serviceHostingEnvironment multipleSiteBindingsEnabled="true" />
-	</system.serviceModel>
-	<runtime>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-		  <dependentAssembly>
-			<assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-			<codeBase version="1.1.20.0" href="bin\ExtraDllVersion\System.Collections.Immutable.dll" />
-			<bindingRedirect oldVersion="0.0.0.0-1.1.20.0" newVersion="1.1.20.0" />
-		  </dependentAssembly>
-		</assemblyBinding>
-	</runtime>
 </configuration>


### PR DESCRIPTION
Web.config cleanup

 - Alpabetically sorted the elements in web.config
 - Removed legacy pre-IIS7 Integrated Mode handler and modules section since C1 requires IIS8
 - Added default Forms Authentication section under system.web to make it easier for people to roll out their own simple login-page without having to struggle figuring out why their Forms Cookie isn't being persisted