### PR TITLE
Marking ServiceLocator.ServiceProvider as public

### DIFF
--- a/Composite/Core/ServiceLocator.cs
+++ b/Composite/Core/ServiceLocator.cs
@@ -108,7 +108,7 @@ namespace Composite.Core
         /// <summary>
         /// Gets an application service provider
         /// </summary>
-        internal static IServiceProvider ServiceProvider
+        public static IServiceProvider ServiceProvider
         {
             get
             {


### PR DESCRIPTION
Marking ServiceLocator.ServiceProvider as public to be able to use it as argument for other framework methods.

Implements #461 