### PR TITLE
Updating WampSharp to current release version (18.3.1)

### DIFF
--- a/Composite/C1Console/Security/Plugins/LoginSessionStore/Runtime/LoginSessionStoreResolver.cs
+++ b/Composite/C1Console/Security/Plugins/LoginSessionStore/Runtime/LoginSessionStoreResolver.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using Castle.Core.Internal;
+using Composite.Core.Extensions;
 
 namespace Composite.C1Console.Security.Plugins.LoginSessionStore.Runtime
 {

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -97,10 +97,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\bin\Microsoft.Practices.ObjectBuilder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WebSockets, Version=0.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WebSockets.0.2.3.1\lib\net45\Microsoft.WebSockets.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -68,8 +68,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.1\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -154,7 +154,14 @@
     <Reference Include="System.ServiceModel.Web">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
@@ -190,19 +197,19 @@
       <HintPath>..\bin\TidyNet.dll</HintPath>
     </Reference>
     <Reference Include="WampSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WampSharp.1.2.5.32-beta\lib\net45\WampSharp.dll</HintPath>
+      <HintPath>..\packages\WampSharp.18.3.1\lib\net45\WampSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WampSharp.AspNet.WebSockets.Server, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WampSharp.AspNet.WebSockets.Server.1.2.5.32-beta\lib\net45\WampSharp.AspNet.WebSockets.Server.dll</HintPath>
+      <HintPath>..\packages\WampSharp.AspNet.WebSockets.Server.18.3.1\lib\net45\WampSharp.AspNet.WebSockets.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WampSharp.NewtonsoftJson, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WampSharp.NewtonsoftJson.1.2.5.32-beta\lib\net45\WampSharp.NewtonsoftJson.dll</HintPath>
+      <HintPath>..\packages\WampSharp.NewtonsoftJson.18.3.1\lib\net45\WampSharp.NewtonsoftJson.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WampSharp.WebSockets, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WampSharp.WebSockets.1.2.5.32-beta\lib\net45\WampSharp.WebSockets.dll</HintPath>
+      <HintPath>..\packages\WampSharp.WebSockets.18.3.1\lib\net45\WampSharp.WebSockets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/Composite/Plugins/Security/LoginSessionStores/WampContextBasedLoginSessionStore/WampContextBasedBasedLoginSessionStore.cs
+++ b/Composite/Plugins/Security/LoginSessionStores/WampContextBasedLoginSessionStore/WampContextBasedBasedLoginSessionStore.cs
@@ -31,7 +31,7 @@ namespace Composite.Plugins.Security.LoginSessionStores.WampContextBasedLoginSes
             {
                 if (WampInvocationContext.Current != null)
                 {
-                    return WampInvocationContext.Current.InvocationDetails.AuthenticationId;
+                    return WampInvocationContext.Current.InvocationDetails.CallerAuthenticationId;
                 }
 
                 return null;

--- a/Composite/packages.config
+++ b/Composite/packages.config
@@ -6,7 +6,6 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Microsoft.WebSockets" version="0.2.3.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
   <package id="System.Reactive" version="3.0.0" targetFramework="net461" />

--- a/Composite/packages.config
+++ b/Composite/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.1" targetFramework="net461" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net471" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net461" />
@@ -15,8 +15,10 @@
   <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net461" />
   <package id="System.Reactive.PlatformServices" version="3.0.0" targetFramework="net461" />
   <package id="System.Reactive.Windows.Threading" version="3.0.0" targetFramework="net461" />
-  <package id="WampSharp" version="1.2.5.32-beta" targetFramework="net461" />
-  <package id="WampSharp.AspNet.WebSockets.Server" version="1.2.5.32-beta" targetFramework="net461" />
-  <package id="WampSharp.NewtonsoftJson" version="1.2.5.32-beta" targetFramework="net461" />
-  <package id="WampSharp.WebSockets" version="1.2.5.32-beta" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net471" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net471" />
+  <package id="WampSharp" version="18.3.1" targetFramework="net471" />
+  <package id="WampSharp.AspNet.WebSockets.Server" version="18.3.1" targetFramework="net471" />
+  <package id="WampSharp.NewtonsoftJson" version="18.3.1" targetFramework="net471" />
+  <package id="WampSharp.WebSockets" version="18.3.1" targetFramework="net471" />
 </packages>

--- a/Website/WebSite.csproj
+++ b/Website/WebSite.csproj
@@ -53,9 +53,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.1\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Composite.XmlSerializers, Version=1.3.3656.19656, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -110,6 +109,9 @@
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/Website/packages.config
+++ b/Website/packages.config
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.1" targetFramework="net461" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net471" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net461" />
-  <package id="PhantomJS" version="2.1.1" targetFramework="net45" />
-  <package id="System.Reactive.Core" version="3.0.0" targetFramework="net461" />
-  <package id="System.Reactive.Interfaces" version="3.0.0" targetFramework="net461" />
-  <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Dataflow" version="4.6.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.0.0" targetFramework="net461" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net461" />
   <package id="Orckestra.AspNet.Roslyn" version="1.0.2" targetFramework="net461" />
+  <package id="PhantomJS" version="2.1.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
+  <package id="System.Reactive.Core" version="3.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Interfaces" version="3.0.0" targetFramework="net461" />
+  <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Updating WampSharp to current release version (18.3.1).

This makes it a more smooth experience to reference C1 via NuGet since things doesn't play so well when a release package is referencing beta packages.