### PR TITLE
Initial commit of a new SiteMap plugin infrastructure

### DIFF
--- a/Composite/AspNet/CmsPageSiteMapNode.cs
+++ b/Composite/AspNet/CmsPageSiteMapNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Web;
 using Composite.Core.Routing;
@@ -10,30 +10,20 @@ namespace Composite.AspNet
     /// <summary>
     /// Represents an <see cref="IPage"/> instance in a sitemap.
     /// </summary>
-    public class CmsPageSiteMapNode: SiteMapNode
+    public class CmsPageSiteMapNode : SiteMapNode, ICmsSiteMapNode, ISchemaOrgSiteMapNode
     {
         private int? _depth;
 
-        /// <summary>
-        /// Gets or sets the culture.
-        /// </summary>
-        /// <value>
-        /// The culture.
-        /// </value>
-        public CultureInfo Culture { get; protected set; }
+        /// <inheritdoc />
+        public CultureInfo Culture { get; }
 
-        /// <summary>
-        /// Gets or sets the priority.
-        /// </summary>
-        /// <value>
-        /// The priority.
-        /// </value>
+        /// <inheritdoc />
         public int? Priority { get; protected set; }
 
         /// <summary>
         /// Gets the current page.
         /// </summary>
-        public IPage Page { get; protected set; }
+        public IPage Page { get; }
 
         /// <summary>
         /// Gets or sets the depth.
@@ -47,10 +37,11 @@ namespace Composite.AspNet
             {
                 if (_depth == null)
                 {
-                    int depth = 0;
-                    Guid id = Page.Id;
+                    var depth = 0;
+                    var id = Page.Id;
 
                     const int maxDepth = 1000;
+
                     using (new DataScope(Page.DataSourceId.PublicationScope, Page.DataSourceId.LocaleScope))
                     {
                         while (id != Guid.Empty && depth < maxDepth)
@@ -58,6 +49,7 @@ namespace Composite.AspNet
                             depth++;
                             id = PageManager.GetParentId(id);
                         }
+
                         if (depth == maxDepth)
                         {
                             throw new InvalidOperationException("Endless page loop");
@@ -66,25 +58,17 @@ namespace Composite.AspNet
 
                     _depth = depth;
                 }
+
                 return _depth.Value;
             }
-            protected set { _depth = value; }
+
+            protected set => _depth = value;
         }
 
-        /// <summary>
-        /// Gets or sets the last modified.
-        /// </summary>
-        /// <value>
-        /// The last modified.
-        /// </value>
-        public DateTime LastModified { get; protected set; }
+        /// <inheritdoc />
+        public DateTime LastModified { get; }
 
-        /// <summary>
-        /// Gets or sets the change frequency.
-        /// </summary>
-        /// <value>
-        /// The change frequency.
-        /// </value>
+        /// <inheritdoc />
         public SiteMapNodeChangeFrequency? ChangeFrequency { get; protected set; }
 
         /// <summary>
@@ -93,7 +77,7 @@ namespace Composite.AspNet
         /// <value>
         /// The document title.
         /// </value>
-        public string DocumentTitle { get; protected set; }
+        public string DocumentTitle { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CmsPageSiteMapNode"/> class.
@@ -111,14 +95,13 @@ namespace Composite.AspNet
             Culture = page.DataSourceId.LocaleScope;
         }
 
-
         /// <exclude />
         public bool Equals(CmsPageSiteMapNode obj)
         {
             return Key == obj.Key && Culture.Equals(obj.Culture);
         }
 
-        /// <exclude />
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             var pageSiteMapNode = obj as CmsPageSiteMapNode;
@@ -126,17 +109,17 @@ namespace Composite.AspNet
             {
                 return Equals(pageSiteMapNode);
             }
-            
+
             return base.Equals(obj);
         }
 
-        /// <exclude />
+        /// <inheritdoc />
         public override SiteMapNode Clone()
         {
             return new CmsPageSiteMapNode(this.Provider, Page);
         }
 
-        /// <exclude />
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Key.GetHashCode() ^ Culture.GetHashCode();

--- a/Composite/AspNet/CmsPagesSiteMapPlugin.cs
+++ b/Composite/AspNet/CmsPagesSiteMapPlugin.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Composite.Core.Extensions;
+using Composite.Core.Routing;
+using Composite.Core.WebClient.Renderings.Page;
+using Composite.Data;
+using Composite.Data.Types;
+
+namespace Composite.AspNet
+{
+    /// <exclude />
+    public class CmsPagesSiteMapPlugin : ISiteMapPlugin
+    {
+        /// <exclude />
+        public List<SiteMapNode> GetChildNodes(SiteMapNode node)
+        {
+            var pageSiteMapNode = node as CmsPageSiteMapNode;
+            if (pageSiteMapNode != null)
+            {
+                using (new DataScope(pageSiteMapNode.Culture))
+                {
+                    var pageChildNodes = PageManager.GetChildrenIDs(pageSiteMapNode.Page.Id)
+                        .Select(PageManager.GetPageById)
+                        .Where(p => p != null)
+                        .Select(p => new CmsPageSiteMapNode(node.Provider, p))
+                        .OfType<SiteMapNode>()
+                        .ToList();
+
+                    return pageChildNodes;
+                }
+            }
+
+            return null;
+        }
+
+        /// <exclude />
+        public SiteMapNode GetParentNode(SiteMapNode node)
+        {
+            var pageSiteMapNode = node as CmsPageSiteMapNode;
+            if (pageSiteMapNode != null)
+            {
+                IPage parentPage = null;
+
+                using (new DataScope(pageSiteMapNode.Culture))
+                {
+                    var parentPageId = PageManager.GetParentId(pageSiteMapNode.Page.Id);
+                    if (parentPageId != Guid.Empty)
+                    {
+                        parentPage = PageManager.GetPageById(parentPageId);
+                    }
+                }
+
+                if (parentPage != null)
+                {
+                    return new CmsPageSiteMapNode(node.Provider, parentPage);
+                }
+
+                return node.Provider.ParentProvider?.GetParentNode(node);
+            }
+
+            return null;
+        }
+
+        /// <exclude />
+        public SiteMapNode FindSiteMapNode(SiteMapProvider provider, HttpContextBase context)
+        {
+            var key = PageRenderer.CurrentPageId.ToString();
+
+            return FindSiteMapNodeFromKey(provider, key);
+        }
+
+        /// <exclude />
+        public SiteMapNode FindSiteMapNode(SiteMapProvider provider, string rawUrl)
+        {
+            var pageUrl = PageUrls.ParseUrl(rawUrl);
+            if (pageUrl == null || !String.IsNullOrEmpty(pageUrl.PathInfo))
+            {
+                return null;
+            }
+
+            var page = pageUrl.GetPage();
+            if (page == null)
+            {
+                return null;
+            }
+
+            return new CmsPageSiteMapNode(provider, page);
+        }
+
+        /// <exclude />
+        public SiteMapNode FindSiteMapNodeFromKey(SiteMapProvider provider, string key)
+        {
+            var pageId = new Guid(key);
+            var page = PageManager.GetPageById(pageId);
+
+            return page != null ? new CmsPageSiteMapNode(provider, page) : null;
+        }
+
+        /// <exclude />
+        public bool IsAccessibleToUser(HttpContextBase context, SiteMapNode node)
+        {
+            return true;
+        }
+    }
+}

--- a/Composite/AspNet/ICmsSiteMapNode.cs
+++ b/Composite/AspNet/ICmsSiteMapNode.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+
+namespace Composite.AspNet
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ICmsSiteMapNode
+    {
+        /// <summary>
+        /// Gets or sets the culture.
+        /// </summary>
+        /// <value>
+        /// The culture.
+        /// </value>
+        CultureInfo Culture { get; }
+    }
+}

--- a/Composite/AspNet/ICmsSiteMapProvider.cs
+++ b/Composite/AspNet/ICmsSiteMapProvider.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Composite.AspNet
+{
+    /// <exclude />
+    public interface ICmsSiteMapProvider
+    {
+        /// <exclude />
+        ICollection<CmsPageSiteMapNode> GetRootNodes();
+    }
+}

--- a/Composite/AspNet/ISchemaOrgSiteMapNode.cs
+++ b/Composite/AspNet/ISchemaOrgSiteMapNode.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Composite.AspNet
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ISchemaOrgSiteMapNode
+    {
+        /// <summary>
+        /// Gets or sets the last modified.
+        /// </summary>
+        /// <value>
+        /// The last modified.
+        /// </value>
+        DateTime LastModified { get; }
+
+        /// <summary>
+        /// Gets or sets the change frequency.
+        /// </summary>
+        /// <value>
+        /// The change frequency.
+        /// </value>
+        SiteMapNodeChangeFrequency? ChangeFrequency { get; }
+
+        /// <summary>
+        /// Gets or sets the priority.
+        /// </summary>
+        /// <value>
+        /// The priority.
+        /// </value>
+        int? Priority { get; }
+    }
+}

--- a/Composite/AspNet/ISiteMapPlugin.cs
+++ b/Composite/AspNet/ISiteMapPlugin.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Web;
+
+namespace Composite.AspNet
+{
+    /// <summary>
+    /// Defines the contract for a plugin to interact with <see cref="CmsPageSiteMapProvider" /> to provide <see cref="SiteMapNode"/> and handle security trimming
+    /// </summary>
+    public interface ISiteMapPlugin
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        List<SiteMapNode> GetChildNodes(SiteMapNode node);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        SiteMapNode GetParentNode(SiteMapNode node);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="rawUrl"></param>
+        /// <returns></returns>
+        SiteMapNode FindSiteMapNode(SiteMapProvider provider, string rawUrl);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        SiteMapNode FindSiteMapNode(SiteMapProvider provider, HttpContextBase context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        SiteMapNode FindSiteMapNodeFromKey(SiteMapProvider provider, string key);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        bool IsAccessibleToUser(HttpContextBase context, SiteMapNode node);
+    }
+}

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -211,7 +211,12 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AspNet\CmsPagesSiteMapPlugin.cs" />
     <Compile Include="AspNet\CmsPageSiteMapProvider.cs" />
+    <Compile Include="AspNet\ICmsSiteMapNode.cs" />
+    <Compile Include="AspNet\ICmsSiteMapProvider.cs" />
+    <Compile Include="AspNet\ISchemaOrgSiteMapNode.cs" />
+    <Compile Include="AspNet\ISiteMapPlugin.cs" />
     <Compile Include="AspNet\Razor\RazorFunction.cs" />
     <Compile Include="AspNet\Razor\RazorHelper.cs" />
     <Compile Include="AspNet\Razor\RazorPageTemplate.cs" />

--- a/Composite/Core/WebClient/ApplicationLevelEventHandlers.cs
+++ b/Composite/Core/WebClient/ApplicationLevelEventHandlers.cs
@@ -109,6 +109,7 @@ namespace Composite.Core.WebClient
 
             services.AddSingleton<IMailer>(new SmtpMailer());
 
+            services.AddTransient<ISiteMapPlugin, CmsPagesSiteMapPlugin>();
 
             VersionedDataHelper.Initialize();
         }


### PR DESCRIPTION
Initial commit of a new SiteMap plugin infrastructure

 - This new plugin system enables 3rd party packages like blog to easily provide SiteMap nodes at runtime which will be automatically reflected in both menus and sitemap.xml.
 - Plugins are registered as services during startup
 - Even normal pages is exposed via a plugin for easy access to solutions to replace the plugin if needed.

No more writing new SiteMapProviders and SiteMapHandlers from scratch to inject custom nodes and if one should find the need, common properties and methods on nodes and provider is exposed via interfaces so we're no longer tied up to concrete class types.

This aims to fullfill the needs in https://github.com/Orckestra/C1-CMS-Foundation/issues/456