### PR TITLE
Fix SiteMapProvider doesn't resolve rootnode correctly for non-page requests

### DIFF
--- a/Composite/AspNet/CmsPageSiteMapProvider.cs
+++ b/Composite/AspNet/CmsPageSiteMapProvider.cs
@@ -152,7 +152,20 @@ namespace Composite.AspNet
                 Guid homePageId = SitemapNavigator.CurrentHomePageId;
                 if (homePageId == Guid.Empty)
                 {
-                    homePageId = PageManager.GetChildrenIDs(Guid.Empty).FirstOrDefault();
+                    var context = HttpContext.Current;
+                    if (context == null)
+                    {
+                        homePageId = PageManager.GetChildrenIDs(Guid.Empty).FirstOrDefault();
+                    }
+                    else
+                    {
+                        using (var data = new DataConnection())
+                        {
+                            var pageNode = data.SitemapNavigator.GetPageNodeByHostname(context.Request.Url.Host);
+
+                            homePageId = pageNode.Id;
+                        }
+                    }
                 }
 
                 if (homePageId != Guid.Empty)


### PR DESCRIPTION
Fix SiteMapProvider doesn't resolve rootnode correctly for non-page requests

When calling RootNode on the SiteMapProvider from outside a CMS Page Request, that is, there is no CurrentPage, the provider incorrectly returns the first website regardless of what hostname is being used.

This fix takes the hostname of the current request into account, when present, to resovle the correct Root node on multisite installations.

Fixes https://github.com/Orckestra/C1-CMS-Foundation/issues/610