### PR TITLE
#652: Fix for consoleId in UrlActionToken querystring

### DIFF
--- a/Composite/C1Console/Actions/UrlActionToken.cs
+++ b/Composite/C1Console/Actions/UrlActionToken.cs
@@ -91,6 +91,11 @@ namespace Composite.C1Console.Actions
 
             string extendedUrl = $"{url}{(url.Contains("?") ? "&" : "?")}EntityToken={HttpUtility.UrlEncode(serializedEntityToken)}";
 
+            if (extendedUrl.IndexOf("consoleId", StringComparison.OrdinalIgnoreCase) == -1)
+            {
+                extendedUrl = $"{extendedUrl}&consoleId={currentConsoleId}";
+            }
+
             ConsoleMessageQueueFacade.Enqueue(
                 new OpenViewMessageQueueItem
                 {


### PR DESCRIPTION
Added consoleId as Query, including backward-compatibility check if the consoleId already exists in the url.