### PR TITLE
Fix: Installing a package with versioned data 

### DIFF
--- a/Composite/Core/PackageSystem/PackageFragmentInstallers/DataPackageFragmentInstaller.cs
+++ b/Composite/Core/PackageSystem/PackageFragmentInstallers/DataPackageFragmentInstaller.cs
@@ -191,7 +191,7 @@ namespace Composite.Core.PackageSystem.PackageFragmentInstallers
                 }
 
 
-                var dataKey = GetKeyPropertyValues(dataType, data, addElement);
+                var dataKey = PopulateAndReturnKeyPropertyValues(dataType, data, addElement);
 
                 if (dataType.AllowOverwrite || dataType.OnlyUpdate)
                 {
@@ -202,7 +202,7 @@ namespace Composite.Core.PackageSystem.PackageFragmentInstallers
 
                     if (existingData != null)
                     {
-                        GetKeyPropertyValues(dataType, existingData, addElement);
+                        PopulateAndReturnKeyPropertyValues(dataType, existingData, addElement);
                         DataFacade.Update(existingData, false, true, false);
 
                         continue;

--- a/Composite/Core/PackageSystem/PackageFragmentInstallers/DataPackageFragmentInstaller.cs
+++ b/Composite/Core/PackageSystem/PackageFragmentInstallers/DataPackageFragmentInstaller.cs
@@ -283,8 +283,8 @@ namespace Composite.Core.PackageSystem.PackageFragmentInstallers
             }
         }
 
-
-        private static DataPropertyValueCollection GetKeyPropertyValues(DataType dataType, IData data, XElement addElement)
+        
+        private static DataPropertyValueCollection PopulateAndReturnKeyPropertyValues(DataType dataType, IData dataToPopulate, XElement addElement)
         {
             var dataKeyPropertyCollection = new DataPropertyValueCollection();
 
@@ -304,7 +304,7 @@ namespace Composite.Core.PackageSystem.PackageFragmentInstallers
                 PropertyInfo propertyInfo = properties[fieldName];
 
                 object fieldValue = ValueTypeConverter.Convert(attribute.Value, propertyInfo.PropertyType);
-                propertyInfo.SetValue(data, fieldValue, null);
+                propertyInfo.SetValue(dataToPopulate, fieldValue, null);
 
                 if (keyPropertyNames.Contains(fieldName) || versionKeyPropertyNames.Contains(fieldName))
                 {

--- a/Composite/Data/DataFacade.cs
+++ b/Composite/Data/DataFacade.cs
@@ -502,7 +502,7 @@ namespace Composite.Data
         // Private helper
         private static Expression GetPredicateExpressionByUniqueKeyFilterExpression(IReadOnlyList<PropertyInfo> keyProperties, DataKeyPropertyCollection dataKeyPropertyCollection, ParameterExpression parameterExpression)
         {
-            if (keyProperties.Count != dataKeyPropertyCollection.Count) throw new ArgumentException("Missing or to many key properties");
+            if (keyProperties.Count != dataKeyPropertyCollection.Count) throw new ArgumentException("Missing or too many key properties");
 
             var propertiesWithValues = new List<Tuple<PropertyInfo, object>>();
             foreach (var kvp in dataKeyPropertyCollection.KeyProperties)
@@ -600,7 +600,7 @@ namespace Composite.Data
         }
 
         /// <summary>
-        /// Returns all data items of the given type, which matchs the provided dataPropertyCollection (property/value pairs)
+        /// Returns all data items of the given type, which matches the provided dataPropertyCollection (property/value pairs)
         /// </summary>
         /// <param name="interfaceType">The data type to query - type is expected to implement a subinterface of IData</param>
         /// <param name="dataPropertyCollection">The properties and values to use for filtering</param>

--- a/Composite/Data/DataFacade.cs
+++ b/Composite/Data/DataFacade.cs
@@ -398,13 +398,6 @@ namespace Composite.Data
         public static IEnumerable<IData> GetDataFromOtherScope(
             IData data, DataScopeIdentifier dataScopeIdentifier, bool useCaching)
         {
-            return GetDataFromOtherScope(data, dataScopeIdentifier, useCaching, true);
-        }
-
-        /// <exclude />
-        public static IEnumerable<IData> GetDataFromOtherScope(
-            IData data, DataScopeIdentifier dataScopeIdentifier, bool useCaching, bool ignoreVersioning)
-        {
             Verify.ArgumentNotNull(data, "data");
             Verify.ArgumentNotNull(dataScopeIdentifier, nameof(dataScopeIdentifier));
 

--- a/Composite/Data/DataFacade.cs
+++ b/Composite/Data/DataFacade.cs
@@ -509,7 +509,7 @@ namespace Composite.Data
         // Private helper
         private static Expression GetPredicateExpressionByUniqueKeyFilterExpression(IReadOnlyList<PropertyInfo> keyProperties, DataKeyPropertyCollection dataKeyPropertyCollection, ParameterExpression parameterExpression)
         {
-            if (keyProperties.Count != dataKeyPropertyCollection.Count) throw new ArgumentException("Missing og to many key properties");
+            if (keyProperties.Count != dataKeyPropertyCollection.Count) throw new ArgumentException("Missing or to many key properties");
 
             var propertiesWithValues = new List<Tuple<PropertyInfo, object>>();
             foreach (var kvp in dataKeyPropertyCollection.KeyProperties)
@@ -605,6 +605,28 @@ namespace Composite.Data
 
             return data;
         }
+
+        /// <summary>
+        /// Returns all data items of the given type, which matchs the provided dataPropertyCollection (property/value pairs)
+        /// </summary>
+        /// <param name="interfaceType">The data type to query - type is expected to implement a subinterface of IData</param>
+        /// <param name="dataPropertyCollection">The properties and values to use for filtering</param>
+        /// <returns>Data matching the provided property values</returns>
+        public static IEnumerable<IData> TryGetDataByLookupKeys(Type interfaceType, DataPropertyValueCollection dataPropertyCollection)
+        {
+            Verify.ArgumentNotNull(interfaceType, nameof(interfaceType));
+            Verify.ArgumentNotNull(dataPropertyCollection, nameof(dataPropertyCollection));
+
+            LambdaExpression lambdaExpression = GetPredicateExpression(interfaceType, dataPropertyCollection);
+
+            MethodInfo methodInfo = GetGetDataWithPredicatMethodInfo(interfaceType);
+
+            var queryable = (IQueryable)methodInfo.Invoke(null, new object[] { lambdaExpression });
+
+            return ((IEnumerable)queryable).Cast<IData>();
+        }
+
+
 
 
         /// <exclude />

--- a/Composite/Data/DataFacade.cs
+++ b/Composite/Data/DataFacade.cs
@@ -371,7 +371,7 @@ namespace Composite.Data
 
             using (new DataScope(dataScopeIdentifier))
             {
-                return DataExpressionBuilder.GetQueryableByData<T>(data, true);
+                return DataExpressionBuilder.GetQueryableByData<T>(data);
             }
         }
 
@@ -384,7 +384,7 @@ namespace Composite.Data
 
             using (new DataScope(cultureInfo))
             {
-                return DataExpressionBuilder.GetQueryableByData<T>(data, true);
+                return DataExpressionBuilder.GetQueryableByData<T>(data);
             }
         }
 
@@ -432,7 +432,7 @@ namespace Composite.Data
             {
                 IQueryable table = GetData(data.DataSourceId.InterfaceType, false);
 
-                IQueryable queryable = DataExpressionBuilder.GetQueryableByData(data, table, ignoreVersioning);
+                IQueryable queryable = DataExpressionBuilder.GetQueryableByData(data, table);
 
                 foreach (object obj in queryable)
                 {

--- a/Composite/Data/Foundation/DataExpressionBuilder.cs
+++ b/Composite/Data/Foundation/DataExpressionBuilder.cs
@@ -29,21 +29,14 @@ namespace Composite.Data.Foundation
         /// <returns></returns>
         public static IQueryable GetQueryableByData(IData data)
         {
-            return GetQueryableByData(data, true);
+            return GetQueryableByData(data, null);
         }
 
 
 
-        public static IQueryable GetQueryableByData(IData data, bool ignoreVersioning)
+        public static IQueryable GetQueryableByData(IData data, IQueryable sourceQueryable)
         {
-            return GetQueryableByData(data, null, ignoreVersioning);
-        }
-
-
-
-        public static IQueryable GetQueryableByData(IData data, IQueryable sourceQueryable, bool ignoreVersioning)
-        {
-            LambdaExpression whereLambdaExpression = GetWhereLambdaExpression(data, ignoreVersioning);
+            LambdaExpression whereLambdaExpression = GetWhereLambdaExpression(data);
 
             if (sourceQueryable == null)
             {
@@ -59,10 +52,10 @@ namespace Composite.Data.Foundation
 
 
 
-        public static IQueryable<T> GetQueryableByData<T>(T data, bool ignoreVersioning)
+        public static IQueryable<T> GetQueryableByData<T>(T data)
             where T : class, IData
         {
-            LambdaExpression whereLambdaExpression = GetWhereLambdaExpression(data, ignoreVersioning);
+            LambdaExpression whereLambdaExpression = GetWhereLambdaExpression(data);
 
             IQueryable queryable = DataFacade.GetData(data.DataSourceId.InterfaceType);
 
@@ -75,9 +68,9 @@ namespace Composite.Data.Foundation
 
 
 
-        public static Delegate GetWherePredicateDelegate(IData data, bool ignoreVersioning)
+        public static Delegate GetWherePredicateDelegate(IData data)
         {
-            LambdaExpression whereLambdaExpression = GetWhereLambdaExpression(data, ignoreVersioning);
+            LambdaExpression whereLambdaExpression = GetWhereLambdaExpression(data);
 
             Delegate resultDelegate = whereLambdaExpression.Compile();
 
@@ -86,7 +79,7 @@ namespace Composite.Data.Foundation
 
 
 
-        private static LambdaExpression GetWhereLambdaExpression(IData data, bool ignoreVersioning)
+        private static LambdaExpression GetWhereLambdaExpression(IData data)
         {
             var propertyInfoes = data.DataSourceId.InterfaceType.GetPhysicalKeyProperties();
 

--- a/Composite/Data/ProcessControlled/ProcessControllers/GenericPublishProcessController/GenericPublishProcessController.cs
+++ b/Composite/Data/ProcessControlled/ProcessControllers/GenericPublishProcessController/GenericPublishProcessController.cs
@@ -370,7 +370,7 @@ namespace Composite.Data.ProcessControlled.ProcessControllers.GenericPublishProc
             var clientActions = visualTrans.Select(newState => _visualTransitionsActions[newState]()).ToList();
 
 
-            IData publicData = DataFacade.GetDataFromOtherScope(data, DataScopeIdentifier.Public, true, false).FirstOrDefault();
+            IData publicData = DataFacade.GetDataFromOtherScope(data, DataScopeIdentifier.Public, true).FirstOrDefault();
             if (publicData != null)
             {
                 var unpublishAction = new ElementAction(new ActionHandle(new ProxyDataActionToken(ActionIdentifier.Unpublish) { DoIgnoreEntityTokenLocking = true }))


### PR DESCRIPTION
Installing a package with versioned data on a site where this data already exists (in the same or a different version) would fail. This fix ensures VersionId is taken into account during the 