### PR TITLE
Fixing a bug with language switcher

### DIFF
--- a/Composite/Core/Localization/LocalizationFacade.cs
+++ b/Composite/Core/Localization/LocalizationFacade.cs
@@ -367,12 +367,26 @@ namespace Composite.Core.Localization
                     UserSettings.RemoveActiveLocaleCultureInfo(username, cultureInfo);
                 }
 
+                IEnumerable<IUserGroupActiveLocale> userGroupsLocales = DataFacade.GetData<IUserGroupActiveLocale>();
+                foreach(IUserGroupActiveLocale el in userGroupsLocales)
+                {
+                    if (el.CultureName == cultureName)
+                    {
+                        DataFacade.Delete(el);
+                    }
+                }
+
                 DataFacade.Delete<ISystemActiveLocale>(systemActiveLocale);
 
                 transactionScope.Complete();
             }
 
             DynamicTypeManager.RemoveLocale(cultureInfo);
+
+            if (makeFlush)
+            {
+                C1Console.Events.GlobalEventSystemFacade.FlushTheSystem(false);
+            }
         }
     }
 }

--- a/Composite/Core/Localization/LocalizationFacade.cs
+++ b/Composite/Core/Localization/LocalizationFacade.cs
@@ -367,15 +367,6 @@ namespace Composite.Core.Localization
                     UserSettings.RemoveActiveLocaleCultureInfo(username, cultureInfo);
                 }
 
-                IEnumerable<IUserGroupActiveLocale> userGroupsLocales = DataFacade.GetData<IUserGroupActiveLocale>();
-                foreach(IUserGroupActiveLocale el in userGroupsLocales)
-                {
-                    if (el.CultureName == cultureName)
-                    {
-                        DataFacade.Delete(el);
-                    }
-                }
-
                 DataFacade.Delete<ISystemActiveLocale>(systemActiveLocale);
 
                 transactionScope.Complete();

--- a/Composite/Data/Types/IUserGroupActiveLocale.cs
+++ b/Composite/Data/Types/IUserGroupActiveLocale.cs
@@ -36,6 +36,7 @@ namespace Composite.Data.Types
         [StringSizeValidator(2, 16)]
         [StoreFieldType(PhysicalStoreFieldType.String, 16)]
         [ImmutableFieldId("{ddc38768-16e8-444c-a982-80f2a55b0b75}")]
+        [ForeignKey(typeof(ISystemActiveLocale), nameof(ISystemActiveLocale.CultureName), AllowCascadeDeletes = true)]
         string CultureName { get; set; }
 	}
 }


### PR DESCRIPTION
Refers to #713 
User group active locales were not deleting. Therefore language switcher remained active.