### PR TITLE
Restoring filtering by GetPageId with Level1

### DIFF
--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -270,6 +270,7 @@
     <Compile Include="Plugins\Forms\WebChannel\UiControlFactories\TemplatedTreelSelectorUiControlFactory.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\DataReference\HomePageSelectorWidgetFunction.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\DataReference\PageReferenceSelectorWidgetFunctionBase.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\String\TreeSelectorWidgetFunction.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\String\HierarchicalSelectorWidgetFunction.cs" />

--- a/Composite/Plugins/Functions/FunctionProviders/StandardFunctionProvider/Pages/GetPageIdFunction.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/StandardFunctionProvider/Pages/GetPageIdFunction.cs
@@ -92,7 +92,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.StandardFunctionProvider
                 return null;
             }
 
-            Guid? pageId = null;
+            Guid pageId = Guid.Empty;
 
             if (entityToken is DataEntityToken dataEntityToken)
             {
@@ -110,10 +110,9 @@ namespace Composite.Plugins.Functions.FunctionProviders.StandardFunctionProvider
             //appears while adding a datafolder element
             else if (typeof(IPage).IsAssignableFrom(Type.GetType(entityToken.Type, throwOnError: false)))
             {
-                Guid.TryParse(entityToken?.Id, out Guid parcedId);
-                pageId = parcedId;
+                Guid.TryParse(entityToken?.Id, out pageId);
             }
-            return pageId == Guid.Empty ? null : pageId;
+            return pageId == Guid.Empty ? null : (Guid?)pageId;
         }
 
 

--- a/Composite/Plugins/Functions/WidgetFunctionProviders/StandardWidgetFunctionProvider/DataReference/HomePageSelectorWidgetFunction.cs
+++ b/Composite/Plugins/Functions/WidgetFunctionProviders/StandardWidgetFunctionProvider/DataReference/HomePageSelectorWidgetFunction.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Xml.Linq;
+using Composite.Core.WebClient.Renderings.Page;
+using Composite.Data;
+using Composite.Data.Types;
+using Composite.Functions;
+using Composite.Plugins.Functions.WidgetFunctionProviders.StandardWidgetFunctionProvider.Foundation;
+
+namespace Composite.Plugins.Functions.WidgetFunctionProviders.StandardWidgetFunctionProvider.DataReference
+{
+    /// <summary>    
+    /// </summary>
+    /// <exclude />
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public sealed class HomePageSelectorWidgetFunction : CompositeWidgetFunctionBase
+    {
+        /// <exclude />
+        public HomePageSelectorWidgetFunction(EntityTokenFactory entityTokenFactory)
+            : base(CompositeName, typeof(DataReference<IPage>), entityTokenFactory)
+        {
+        }
+
+        private const string CompositeName = CommonNamespace + ".DataReference" + ".HomePageSelector";
+
+        /// <exclude />
+        public override XElement GetWidgetMarkup(ParameterList parameters, string label, HelpDefinition helpDefinition, string bindingSourceName)
+        {
+            return StandardWidgetFunctions.BuildStaticCallPopulatedSelectorFormsMarkup(
+                parameters: parameters,
+                label: label,
+                helpDefinition: helpDefinition,
+                bindingSourceName: bindingSourceName,
+                optionsGeneratingStaticType: typeof(HomePageSelectorWidgetFunction),
+                optionsGeneratingStaticMethodName: nameof(GetHomePages),
+                optionsGeneratingStaticMethodParameterValue: null,
+                optionsObjectKeyPropertyName: "Key",
+                optionsObjectLabelPropertyName: "Label",
+                multiSelect: false,
+                compactMode: true,
+                required: true,
+                bindToString: false);
+        }
+
+        /// <summary>
+        /// To be called through reflection
+        /// </summary>
+        /// <exclude />
+        public static IEnumerable GetHomePages()
+        {
+            foreach (var element in PageStructureInfo.GetSiteMap())
+            {
+                yield return new
+                {
+                    Key = PageStructureInfo.GetIdForPageElement(element),
+                    Label = PageStructureInfo.GetLabelForPageElement("", element)
+                };
+            }
+        }
+    }
+}

--- a/Composite/Plugins/Functions/WidgetFunctionProviders/StandardWidgetFunctionProvider/DataReference/PageReferenceSelectorWidgetFunctionBase.cs
+++ b/Composite/Plugins/Functions/WidgetFunctionProviders/StandardWidgetFunctionProvider/DataReference/PageReferenceSelectorWidgetFunctionBase.cs
@@ -1,6 +1,5 @@
 using Composite.Core.Types;
 using Composite.Core.Xml;
-using Composite.Data;
 using Composite.Data.Types;
 using Composite.Functions;
 using Composite.Plugins.Elements.ElementProviders.PageElementProvider;
@@ -14,23 +13,14 @@ namespace Composite.Plugins.Functions.WidgetFunctionProviders.StandardWidgetFunc
     {
         protected const string CompositeNameBase = CommonNamespace + ".DataReference";
 
-        private const string HomePageIdParameterName = "HomePageId";
-        protected PageReferenceSelectorWidgetFunctionBase(string compositeName, Type returnType, EntityTokenFactory entityTokenFactory)
-            : base(compositeName, returnType, entityTokenFactory)
-        {
-            var boolProvider = StandardWidgetFunctions.GetBoolSelectorWidget(
-                "Enabled: filter pages by active website",
-                "Disabled: no filter, show all websites pages (default)");
 
-            base.AddParameterProfile(new ParameterProfile(
-                HomePageIdParameterName,
-                typeof(bool),
-                false,
-                new ConstantValueProvider(false),
-                boolProvider,
-                "Filter by website",
-                new HelpDefinition("If enabled, then for selecting will be enabled only pages from a website of a current active element."),
-                false));
+        private const string HomePageIdParameterName = "HomePageId";
+        protected PageReferenceSelectorWidgetFunctionBase(string compositeName, Type returnType, EntityTokenFactory entityTokenFactory) : base(compositeName, returnType, entityTokenFactory)
+        {
+            base.AddParameterProfile(
+                new ParameterProfile(HomePageIdParameterName, typeof(Guid?), false,
+                    new ConstantValueProvider(null), new WidgetFunctionProvider(new HomePageSelectorWidgetFunction(entityTokenFactory)), null,
+                    "Filter by Home Page", new HelpDefinition("Use this field to filter by root website. If not set all websites are shown. You can use GetPageId function to get current page")));
         }
 
         public override XElement GetWidgetMarkup(ParameterList parameters, string label, HelpDefinition helpDefinition, string bindingSourceName)
@@ -52,22 +42,15 @@ namespace Composite.Plugins.Functions.WidgetFunctionProviders.StandardWidgetFunc
         private XElement GetSearchToken(ParameterList parameters, XElement selector)
         {
             var parameter = GetParameterElement(parameters);
-            if (parameter == null || !bool.TryParse(parameter.ToString(), out bool result) || !result)
+            if (parameter == null)
                 return null;
 
             var f = Namespaces.BindingFormsStdFuncLib10;
-            var ft = Namespaces.Function10;
-
             var element = new XElement(selector.Name.Namespace + "DataReferenceTreeSelector.SearchToken",
                 new XElement(f + "StaticMethodCall",
                     new XAttribute("Type", TypeManager.SerializeType(typeof(PageReferenceSelectorWidgetFunctionBase))),
                     new XAttribute("Method", nameof(GetPageSearchToken)),
-                    new XElement(f + "StaticMethodCall.Parameters",
-                        new XElement(ft + "function",
-                            new XAttribute("name", "Composite.Pages.GetPageId"),
-                            new XElement(ft + "param",
-                                new XAttribute("name", nameof(SitemapScope)),
-                                new XAttribute("value", SitemapScope.Level1))))));
+                    new XElement(f + "StaticMethodCall.Parameters", parameter)));
 
             return element;
         }


### PR DESCRIPTION
After discussion with Taras were decided to keep functionality as before (choosing GetPageId and selecting Level1) and to affect only bug fixes, without direct bool filter.