### PR TITLE
Expand implementations for NoHttpRazorContext

### DIFF
--- a/Composite/AspNet/Razor/NoHttpRazorContext.cs
+++ b/Composite/AspNet/Razor/NoHttpRazorContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Web;
 using System.Web.Instrumentation;
@@ -9,27 +9,16 @@ namespace Composite.AspNet.Razor
     internal class NoHttpRazorContext : HttpContextBase
     {
         private readonly IDictionary _items = new Hashtable();
-		public override IDictionary Items
-		{
-			get { return _items; }
-		}
-
-		private readonly HttpRequestBase _request = new NoHttpRazorRequest();
-		public override HttpRequestBase Request
-		{
-			get { return _request; }
-		}
-
+        private readonly HttpRequestBase _request = new NoHttpRazorRequest();
+        private readonly HttpResponseBase _response = new NoHttpRazorResponse();
         private readonly PageInstrumentationService _pageInstrumentation = new PageInstrumentationService();
-        public override PageInstrumentationService PageInstrumentation
-        {
-            get { return _pageInstrumentation; }
-        }
 
-        public override HttpServerUtilityBase Server
-        {
-            get { throw new NotSupportedException("Usage of 'Server' isn't supported without HttpContext. Use System.Web.HttpUtility for [html|url] [encoding|decoding]"); }
-        }
+        public override IDictionary Items => _items;
+		public override HttpRequestBase Request => _request;
+        public override HttpResponseBase Response => _response;
+        public override PageInstrumentationService PageInstrumentation => _pageInstrumentation;
+
+        public override HttpServerUtilityBase Server => throw new NotSupportedException("Usage of 'Server' isn't supported without HttpContext. Use System.Web.HttpUtility for [html|url] [encoding|decoding]");
 
         public override object GetService(Type serviceType)
         {

--- a/Composite/AspNet/Razor/NoHttpRazorRequest.cs
+++ b/Composite/AspNet/Razor/NoHttpRazorRequest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Web;
 using System.Web.Hosting;
@@ -13,86 +14,35 @@ namespace Composite.AspNet.Razor
         private NameValueCollection _params;
         private NameValueCollection _serverVariables;
         private HttpCookieCollection _cookies;
+        private HttpBrowserCapabilitiesBase _browser;
 
-        public override string ApplicationPath
+        public override string ApplicationPath => HostingEnvironment.ApplicationVirtualPath;
+        public override string PhysicalApplicationPath => HostingEnvironment.ApplicationPhysicalPath;
+
+        public override HttpBrowserCapabilitiesBase Browser => _browser ?? (_browser = new HttpBrowserCapabilitiesWrapper(new HttpBrowserCapabilities
         {
-            get { return HostingEnvironment.ApplicationVirtualPath; }
+            Capabilities = new Dictionary<string, string>()
+        }));
+
+        public override HttpCookieCollection Cookies => _cookies ?? (_cookies = new HttpCookieCollection());
+        public override bool IsLocal => false;
+        public override NameValueCollection Form => _form ?? (_form = new NameValueCollection());
+        public override NameValueCollection Headers => _headers ?? (_headers = new NameValueCollection());
+        public override string HttpMethod => "GET";
+        public override bool IsAuthenticated => false;
+        public override bool IsSecureConnection => false;
+        public override string this[string key] => null;
+        public override NameValueCollection Params => _params ?? (_params = new NameValueCollection());
+        public override string PathInfo => null;
+        public override NameValueCollection QueryString => _queryString ?? (_queryString = new NameValueCollection());
+
+        public override string RequestType
+        {
+            get => HttpMethod;
+            set => throw new NotSupportedException();
         }
 
-        public override string PhysicalApplicationPath
-        {
-            get { return HostingEnvironment.ApplicationPhysicalPath; }
-        }
-
-        public override HttpCookieCollection Cookies
-        {
-            get { return _cookies ?? (_cookies = new HttpCookieCollection()); }
-        }
-
-        public override bool IsLocal
-		{
-			get { return false; }
-		}
-
-        public override NameValueCollection Form
-        {
-            get { return _form ?? (_form = new NameValueCollection()); }
-        }
-
-        public override NameValueCollection Headers
-        {
-            get { return _headers ?? (_headers = new NameValueCollection());}
-        }
-
-        public override string HttpMethod
-        {
-            get { return "GET"; }
-        }
-
-        public override bool IsAuthenticated
-        {
-            get { return false; }
-        }
-
-        public override bool IsSecureConnection
-        {
-            get { return false; }
-        }
-
-        public override string this[string key]
-        {
-            get { return null; }
-        }
-
-        public override NameValueCollection Params
-        {
-            get { return _params ?? (_params = new NameValueCollection()); }
-        }
-
-        public override string PathInfo
-        {
-            get { return null; }
-        }
-
-        public override NameValueCollection QueryString
-        {
-            get { return _queryString ?? (_queryString = new NameValueCollection()); }
-        }
-
-        public override string RequestType 
-        {
-            get { return HttpMethod; }
-            set { throw new NotSupportedException();} 
-        }
-
-        public override NameValueCollection ServerVariables
-        {
-            get { return _serverVariables ?? (_serverVariables = new NameValueCollection()); }
-        }
-
-        public override string UserAgent
-        {
-            get { return ""; }
-        }
+        public override NameValueCollection ServerVariables => _serverVariables ?? (_serverVariables = new NameValueCollection());
+        public override string UserAgent => "";
     }
 }

--- a/Composite/AspNet/Razor/NoHttpRazorResponse.cs
+++ b/Composite/AspNet/Razor/NoHttpRazorResponse.cs
@@ -1,0 +1,14 @@
+using System.Collections.Specialized;
+using System.Web;
+
+namespace Composite.AspNet.Razor
+{
+    internal class NoHttpRazorResponse : HttpResponseBase
+    {
+        private NameValueCollection _headers;
+        private HttpCookieCollection _cookies;
+
+        public override HttpCookieCollection Cookies => _cookies ?? (_cookies = new HttpCookieCollection());
+        public override NameValueCollection Headers => _headers ?? (_headers = new NameValueCollection());
+    }
+}

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -216,6 +216,7 @@
     <Compile Include="AspNet\ICmsSiteMapProvider.cs" />
     <Compile Include="AspNet\ISchemaOrgSiteMapNode.cs" />
     <Compile Include="AspNet\ISiteMapPlugin.cs" />
+    <Compile Include="AspNet\Razor\NoHttpRazorResponse.cs" />
     <Compile Include="AspNet\Razor\RazorFunction.cs" />
     <Compile Include="AspNet\Razor\RazorHelper.cs" />
     <Compile Include="AspNet\Razor\RazorPageTemplate.cs" />


### PR DESCRIPTION
Expand NoHttpRazorContext so it supports querying for response cookies and browser capabilities.

Why? There is at least one rare case where, when calling RenderPage from within a RazorFunction without a HttpContext where the callstack with end up like this

```
System.InvalidOperationException: Failed to get value for function '...' ---> System.NotImplementedException: The method or operation is not implemented.
   at System.Web.HttpContextBase.get_Response()
   at System.Web.WebPages.CookieBrowserOverrideStore.GetOverriddenUserAgent(HttpContextBase httpContext)
   at System.Web.WebPages.BrowserHelpers.GetOverriddenUserAgent(HttpContextBase httpContext)
   at System.Web.WebPages.BrowserHelpers.GetOverriddenBrowser(HttpContextBase httpContext, Func`2 createBrowser)
   at System.Web.WebPages.DisplayModeProvider.<.ctor>b__2(HttpContextBase context)
   at System.Web.WebPages.DisplayModeProvider.GetDisplayInfoForVirtualPath(String virtualPath, HttpContextBase httpContext, Func`2 virtualPathExists, IDisplayMode currentDisplayMode, Boolean requireConsistentDisplayMode)
   at System.Web.WebPages.WebPageBase.CreatePageFromVirtualPath(String virtualPath, HttpContextBase httpContext, Func`2 virtualPathExists, DisplayModeProvider displayModeProvider, IDisplayMode displayMode)
   at System.Web.WebPages.WebPageBase.<>c__DisplayClass3.<RenderPageCore>b__2(TextWriter writer)
   at System.Web.WebPages.WebPageBase.Write(HelperResult result)
```

This pull requests adds missing implementations to NoHttpRazorContext for Response and Cookies