### PR TITLE
Fix edit page after adding own PublishDate field to a metadata type

### DIFF
--- a/Composite/Data/DynamicTypes/DataTypeDescriptorFormsHelper.cs
+++ b/Composite/Data/DynamicTypes/DataTypeDescriptorFormsHelper.cs
@@ -15,6 +15,7 @@ using Composite.Data.DynamicTypes.Foundation;
 using Composite.Data.ProcessControlled;
 using Composite.Data.ProcessControlled.ProcessControllers.GenericPublishProcessController;
 using Composite.Data.PublishScheduling;
+using Composite.Data.Types;
 using Composite.Data.Validation;
 using Composite.Data.Validation.ClientValidationRules;
 using Composite.Functions;
@@ -785,10 +786,10 @@ namespace Composite.Data.DynamicTypes
             }
             else
             {
-                if (_dataTypeDescriptor.SuperInterfaces.Contains(typeof(IPublishControlled)))
+                if (_showPublicationStatusSelector && _dataTypeDescriptor.SuperInterfaces.Contains(typeof(IPublishControlled)))
                 {
-                    fieldNameToBindingNameMapper.Add("PublishDate", "PublishDate");
-                    fieldNameToBindingNameMapper.Add("UnpublishDate", "UnpublishDate");
+                    fieldNameToBindingNameMapper.Add(nameof(IPublishSchedule.PublishDate), nameof(IPublishSchedule.PublishDate));
+                    fieldNameToBindingNameMapper.Add(nameof(IUnpublishSchedule.UnpublishDate), nameof(IUnpublishSchedule.UnpublishDate));
                 }
 
                 Func<XElement, IEnumerable<XAttribute>> getBindingsFunc =


### PR DESCRIPTION
When adding own Publish/Upublishdate fields to a Page Metadata type and using custom form markup, the page fails to open in the console with the error

```
System.ArgumentException: An item with the same key has already been added.   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at Composite.Data.DynamicTypes.DataTypeDescriptorFormsHelper.GenerateForm()
```

This is due to a missing check for `_showPublicationStatusSelector` when using a Custom form, since the code, without further checks, forcebly adds the fields PublishDate and UnpublishDate to bindings even though they are already there.

Fixes issue https://github.com/Orckestra/C1-CMS-Foundation/issues/778