### PR TITLE
Image resizing: pluggable image formats with IImageFileFormatProvider

### DIFF
--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -258,6 +258,8 @@
     <Compile Include="Core\Serialization\CompositeJsonSerializer.cs" />
     <Compile Include="Core\Serialization\CompositeSerializationBinder.cs" />
     <Compile Include="Core\Types\CSharpCodeProviderFactory.cs" />
+    <Compile Include="Core\WebClient\Media\DefaultImageFileFormatProvider.cs" />
+    <Compile Include="Core\WebClient\Media\IImageFileFormatProvider.cs" />
     <Compile Include="Core\WebClient\PageStructureRpc.cs" />
     <Compile Include="Core\WebClient\Renderings\Page\PagePreviewContext.cs" />
     <Compile Include="Core\WebClient\Renderings\Page\IPageContentFilter.cs" />

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Core\Types\CSharpCodeProviderFactory.cs" />
     <Compile Include="Core\WebClient\Media\DefaultImageFileFormatProvider.cs" />
     <Compile Include="Core\WebClient\Media\IImageFileFormatProvider.cs" />
+    <Compile Include="Core\WebClient\Media\ImageFormatProviders.cs" />
     <Compile Include="Core\WebClient\PageStructureRpc.cs" />
     <Compile Include="Core\WebClient\Renderings\Page\PagePreviewContext.cs" />
     <Compile Include="Core\WebClient\Renderings\Page\IPageContentFilter.cs" />

--- a/Composite/Core/WebClient/ApplicationLevelEventHandlers.cs
+++ b/Composite/Core/WebClient/ApplicationLevelEventHandlers.cs
@@ -18,6 +18,7 @@ using Composite.Core.Logging;
 using Composite.Core.Routing;
 using Composite.Core.Threading;
 using Composite.Core.Types;
+using Composite.Core.WebClient.Media;
 using Composite.Data.Types;
 using Composite.Functions;
 using Composite.Plugins.Elements.UrlToEntityToken;
@@ -101,6 +102,7 @@ namespace Composite.Core.WebClient
             services.AddRoutedData();
             services.AddDataActionTokenResolver();
             services.AddDefaultSearchDocumentSourceProviders();
+            services.AddDefaultImageFileFormatProviders();
 
             InternalUrls.Register(new MediaInternalUrlConverter());
             InternalUrls.Register(new PageInternalUrlConverter());

--- a/Composite/Core/WebClient/Media/DefaultImageFileFormatProvider.cs
+++ b/Composite/Core/WebClient/Media/DefaultImageFileFormatProvider.cs
@@ -1,61 +1,39 @@
-using Composite.Core.IO;
 using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
 
 namespace Composite.Core.WebClient.Media
 {
     internal class DefaultImageFileFormatProvider: IImageFileFormatProvider
     {
-        private static readonly ImageCodecInfo JpegCodecInfo = ImageCodecInfo.GetImageEncoders().First(codec => codec.FormatID == ImageFormat.Jpeg.Guid);
-
         private readonly Action<Bitmap, string, int?> _saveAction;
 
-        public DefaultImageFileFormatProvider(string mediaType, string extension, Action<Bitmap, string, int?> saveAction)
+        public DefaultImageFileFormatProvider(string mediaType, string extension, Action<Bitmap, string, int?> saveAction, bool canSetImageQuality = false)
         {
             MediaType = mediaType;
             FileExtension = extension;
             _saveAction = saveAction;
+            CanSetImageQuality = canSetImageQuality;
         }
 
         public string MediaType { get; }
 
         public string FileExtension { get; }
 
-        public bool CanSetCompressionQuality { get; private set; }
+        public bool CanSetImageQuality { get; }
+
+        public bool CanReadImageSize => true;
+
+        public bool TryGetSize(Stream imageStream, out Size size)
+        {
+            return ImageSizeReader.TryGetSize(imageStream, out size);
+        }
 
         public Bitmap LoadImageFromStream(Stream stream) => new Bitmap(stream);
 
         public void SaveImageToFile(Bitmap image, string outputFilePath, int? qualityPercentage = null)
         {
             _saveAction(image, outputFilePath, qualityPercentage);
-        }
-
-        private static Action<Bitmap, string, int?> GetSaveInFormatFunction(ImageFormat imageFormat) =>
-            (resizedImage, outputFilePath, quality) => resizedImage.Save(outputFilePath, imageFormat);
-
-        public static IEnumerable<IImageFileFormatProvider> GetDefaultProviders()
-        {
-            return new List<DefaultImageFileFormatProvider>
-            {
-                new DefaultImageFileFormatProvider(MimeTypeInfo.Jpeg, "jpeg", (resizedImage, outputFilePath, quality) =>
-                {
-                    var parameters = new EncoderParameters(1);
-                    parameters.Param[0] = new EncoderParameter(Encoder.Quality, quality ?? 75);
-
-                    resizedImage.Save(outputFilePath, JpegCodecInfo, parameters);
-                })
-                {
-                    CanSetCompressionQuality = true
-                },
-                new DefaultImageFileFormatProvider(MimeTypeInfo.Png, "png", GetSaveInFormatFunction(ImageFormat.Png)),
-                new DefaultImageFileFormatProvider(MimeTypeInfo.Gif, "gif", GetSaveInFormatFunction(ImageFormat.Gif)),
-                new DefaultImageFileFormatProvider(MimeTypeInfo.Tiff, "tiff", GetSaveInFormatFunction(ImageFormat.Tiff)),
-                new DefaultImageFileFormatProvider(MimeTypeInfo.Bmp, "bmp", GetSaveInFormatFunction(ImageFormat.Bmp))
-            };
         }
     }
 }

--- a/Composite/Core/WebClient/Media/DefaultImageFileFormatProvider.cs
+++ b/Composite/Core/WebClient/Media/DefaultImageFileFormatProvider.cs
@@ -1,0 +1,61 @@
+using Composite.Core.IO;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+
+namespace Composite.Core.WebClient.Media
+{
+    internal class DefaultImageFileFormatProvider: IImageFileFormatProvider
+    {
+        private static readonly ImageCodecInfo JpegCodecInfo = ImageCodecInfo.GetImageEncoders().First(codec => codec.FormatID == ImageFormat.Jpeg.Guid);
+
+        private readonly Action<Bitmap, string, int?> _saveAction;
+
+        public DefaultImageFileFormatProvider(string mediaType, string extension, Action<Bitmap, string, int?> saveAction)
+        {
+            MediaType = mediaType;
+            FileExtension = extension;
+            _saveAction = saveAction;
+        }
+
+        public string MediaType { get; }
+
+        public string FileExtension { get; }
+
+        public bool CanSetCompressionQuality { get; private set; }
+
+        public Bitmap LoadImageFromStream(Stream stream) => new Bitmap(stream);
+
+        public void SaveImageToFile(Bitmap image, string outputFilePath, int? qualityPercentage = null)
+        {
+            _saveAction(image, outputFilePath, qualityPercentage);
+        }
+
+        private static Action<Bitmap, string, int?> GetSaveInFormatFunction(ImageFormat imageFormat) =>
+            (resizedImage, outputFilePath, quality) => resizedImage.Save(outputFilePath, imageFormat);
+
+        public static IEnumerable<IImageFileFormatProvider> GetDefaultProviders()
+        {
+            return new List<DefaultImageFileFormatProvider>
+            {
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Jpeg, "jpeg", (resizedImage, outputFilePath, quality) =>
+                {
+                    var parameters = new EncoderParameters(1);
+                    parameters.Param[0] = new EncoderParameter(Encoder.Quality, quality ?? 75);
+
+                    resizedImage.Save(outputFilePath, JpegCodecInfo, parameters);
+                })
+                {
+                    CanSetCompressionQuality = true
+                },
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Png, "png", GetSaveInFormatFunction(ImageFormat.Png)),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Gif, "gif", GetSaveInFormatFunction(ImageFormat.Gif)),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Tiff, "tiff", GetSaveInFormatFunction(ImageFormat.Tiff)),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Bmp, "bmp", GetSaveInFormatFunction(ImageFormat.Bmp))
+            };
+        }
+    }
+}

--- a/Composite/Core/WebClient/Media/DefaultImageFileFormatProvider.cs
+++ b/Composite/Core/WebClient/Media/DefaultImageFileFormatProvider.cs
@@ -10,9 +10,9 @@ namespace Composite.Core.WebClient.Media
 
         public DefaultImageFileFormatProvider(string mediaType, string extension, Action<Bitmap, string, int?> saveAction, bool canSetImageQuality = false)
         {
-            MediaType = mediaType;
-            FileExtension = extension;
-            _saveAction = saveAction;
+            MediaType = mediaType ?? throw new ArgumentNullException(nameof(mediaType));
+            FileExtension = extension ?? throw new ArgumentNullException(nameof(extension));
+            _saveAction = saveAction ?? throw new ArgumentNullException(nameof(saveAction));
             CanSetImageQuality = canSetImageQuality;
         }
 

--- a/Composite/Core/WebClient/Media/IImageFileFormatProvider.cs
+++ b/Composite/Core/WebClient/Media/IImageFileFormatProvider.cs
@@ -21,7 +21,20 @@ namespace Composite.Core.WebClient.Media
         /// <summary>
         /// Indicates whether the provider allows specifying quality percentage when saving an image.
         /// </summary>
-        bool CanSetCompressionQuality { get; }
+        bool CanSetImageQuality { get; }
+
+        /// <summary>
+        /// Indicates whether the provider allows reading image dimensions from the beginning of the stream.
+        /// </summary>
+        bool CanReadImageSize { get; }
+
+        /// <summary>
+        /// Tries to read image's size from the file header.
+        /// </summary>
+        /// <param name="imageStream">The input stream with an image.</param>
+        /// <param name="size">The size of the image</param>
+        /// <returns><value>True</value> if the image size was extracted successfully.</returns>
+        bool TryGetSize(Stream imageStream, out Size size);
 
         /// <summary>
         /// Loads a <see cref="Bitmap"/> out of stream .

--- a/Composite/Core/WebClient/Media/IImageFileFormatProvider.cs
+++ b/Composite/Core/WebClient/Media/IImageFileFormatProvider.cs
@@ -1,0 +1,41 @@
+using System.Drawing;
+using System.IO;
+
+namespace Composite.Core.WebClient.Media
+{
+    /// <summary>
+    /// A provider that enables reading/saving images for a specific image format.
+    /// </summary>
+    public interface IImageFileFormatProvider
+    {
+        /// <summary>
+        /// A media type (aka MIME type) that describes the image format (f.e. "image/jpeg").
+        /// </summary>
+        string MediaType { get; }
+
+        /// <summary>
+        /// A file extension that is associated with the image format.
+        /// </summary>
+        string FileExtension { get; }
+
+        /// <summary>
+        /// Indicates whether the provider allows specifying quality percentage when saving an image.
+        /// </summary>
+        bool CanSetCompressionQuality { get; }
+
+        /// <summary>
+        /// Loads a <see cref="Bitmap"/> out of stream .
+        /// </summary>
+        /// <param name="stream">The input stream.</param>
+        /// <returns></returns>
+        Bitmap LoadImageFromStream(Stream stream);
+
+        /// <summary>
+        /// Saves an image to a file with a given quality.
+        /// </summary>
+        /// <param name="image">The image to be saved.</param>
+        /// <param name="outputFilePath">The full path to a file.</param>
+        /// <param name="qualityPercentage">The desired quality of the image - from 1 to 100.</param>
+        void SaveImageToFile(Bitmap image, string outputFilePath, int? qualityPercentage = null);
+    }
+}

--- a/Composite/Core/WebClient/Media/ImageFormatProviders.cs
+++ b/Composite/Core/WebClient/Media/ImageFormatProviders.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using Composite.Core.IO;
+using Microsoft.Extensions.DependencyInjection;
+
+
+namespace Composite.Core.WebClient.Media
+{
+    internal static class ImageFormatProviders
+    {
+        private static readonly ImageCodecInfo JpegCodecInfo = ImageCodecInfo.GetImageEncoders().First(codec => codec.FormatID == ImageFormat.Jpeg.Guid);
+
+        private static Action<Bitmap, string, int?> GetSaveInFormatFunction(ImageFormat imageFormat) =>
+            (resizedImage, outputFilePath, quality) => resizedImage.Save(outputFilePath, imageFormat);
+
+        internal static void AddDefaultImageFileFormatProviders(this IServiceCollection services)
+        {
+            var providers = new List<DefaultImageFileFormatProvider>
+            {
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Jpeg, "jpeg", (resizedImage, outputFilePath, quality) =>
+                {
+                    var parameters = new EncoderParameters(1);
+                    parameters.Param[0] = new EncoderParameter(Encoder.Quality, quality ?? 75);
+
+                    resizedImage.Save(outputFilePath, JpegCodecInfo, parameters);
+                }, canSetImageQuality: true),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Png, "png", GetSaveInFormatFunction(ImageFormat.Png)),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Gif, "gif", GetSaveInFormatFunction(ImageFormat.Gif)),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Tiff, "tiff", GetSaveInFormatFunction(ImageFormat.Tiff)),
+                new DefaultImageFileFormatProvider(MimeTypeInfo.Bmp, "bmp", GetSaveInFormatFunction(ImageFormat.Bmp))
+            };
+
+            providers.ForEach(p => services.AddSingleton<IImageFileFormatProvider>(p));
+        }
+    }
+}

--- a/Composite/Core/WebClient/Media/ImageResizer.cs
+++ b/Composite/Core/WebClient/Media/ImageResizer.cs
@@ -38,7 +38,14 @@ namespace Composite.Core.WebClient.Media
                 var customProviders = ServiceLocator.GetServices<IImageFileFormatProvider>().ToList();
 
                 var result = new Dictionary<string, IImageFileFormatProvider>();
-                customProviders.ForEach(provider => result[provider.MediaType] = provider);
+                customProviders.ForEach(provider =>
+                {
+                    var mediaType = provider.MediaType;
+                    if (string.IsNullOrWhiteSpace(mediaType))
+                        throw new InvalidOperationException($"Empty MediaType returned by provider {provider.GetType().FullName}");
+
+                    result[mediaType] = provider;
+                });
 
                 return _imageFormatProviders = result;
             }

--- a/Composite/Core/WebClient/Media/ResizingOptions.cs
+++ b/Composite/Core/WebClient/Media/ResizingOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
@@ -23,7 +23,7 @@ namespace Composite.Core.WebClient.Media
         private int? _qualityOverride;
 
         /// <summary>
-        /// Image heigth
+        /// Image height
         /// </summary>
         public int? Height { get; set; }
 
@@ -76,6 +76,12 @@ namespace Composite.Core.WebClient.Media
         public ResizingAction ResizingAction { get; set; }
 
         /// <summary>
+        /// The preferred media type for the generated resized image.
+        /// If the media type isn't supported, the original image will be returned.
+        /// </summary>
+        public string MediaType { get; set; }
+
+        /// <summary>
         /// Indicates whether any options were specified
         /// </summary>
         public bool IsEmpty => Height == null && Width == null && MaxHeight == null && MaxWidth == null && _qualityOverride == null;
@@ -126,6 +132,8 @@ namespace Composite.Core.WebClient.Media
                 {
                     ResizingAction = (ResizingAction)Enum.Parse(typeof(ResizingAction), attr.Value, true);
                 }
+
+                MediaType = (string) e.Attribute("mediaType");
             }
         }
 
@@ -183,6 +191,12 @@ namespace Composite.Core.WebClient.Media
             else
             {
                 result.ResizingAction = ResizingAction.Stretch;
+            }
+
+            var mediaType = queryString["mt"];
+            if (!string.IsNullOrEmpty(mediaType))
+            {
+                result.MediaType = mediaType;
             }
 
             return result;
@@ -251,6 +265,12 @@ namespace Composite.Core.WebClient.Media
             {
                 sb.Append(sb.Length == 0 ? String.Empty : "&");
                 sb.Append("action=").Append(ResizingAction.ToString().ToLowerInvariant());
+            }
+
+            if (!string.IsNullOrWhiteSpace(MediaType))
+            {
+                sb.Append(sb.Length == 0 ? String.Empty : "&");
+                sb.Append("mt=").Append(MediaType);
             }
 
             return sb.ToString();

--- a/Website/Renderers/ShowMedia.ashx
+++ b/Website/Renderers/ShowMedia.ashx
@@ -567,7 +567,7 @@ public class ShowMedia : IHttpHandler, IReadOnlySessionState
 
         var preferredMediaType = resizingOptions.MediaType;
 
-        if (resizingOptions == null || resizingOptions.IsEmpty
+        if (resizingOptions.IsEmpty
             || (preferredMediaType != null && !ImageResizer.TargetMediaTypeSupported(preferredMediaType)))
         {
             resizedImageMediaType = mediaType;
@@ -578,7 +578,7 @@ public class ShowMedia : IHttpHandler, IReadOnlySessionState
 
         try
         {
-            string resizedImageFilePath = ImageResizer.GetResizedImage(context.Server, file, resizingOptions, targetImageMediaType);
+            string resizedImageFilePath = ImageResizer.GetResizedImage(file, resizingOptions, mediaType, targetImageMediaType);
 
             resizedImageMediaType = resizedImageFilePath != null ? targetImageMediaType : mediaType;
 

--- a/Website/Renderers/ShowMedia.ashx
+++ b/Website/Renderers/ShowMedia.ashx
@@ -205,7 +205,7 @@ public class ShowMedia : IHttpHandler, IReadOnlySessionState
         }
 
         bool download = (string.IsNullOrEmpty(context.Request["download"]) ?
-            !CabBePreviewedInBrowser(context, file.MimeType) :
+            !CanBePreviewedInBrowser(context, file.MimeType) :
             context.Request["download"] != "false");
 
         context.Response.AddHeader("Content-Disposition", "{0};filename=\"{1}\"".FormatWith((download ? "attachment" : "inline"), encodedFileName));
@@ -531,7 +531,7 @@ public class ShowMedia : IHttpHandler, IReadOnlySessionState
     }
 
 
-    private static bool CabBePreviewedInBrowser(HttpContext context, string mediaType)
+    private static bool CanBePreviewedInBrowser(HttpContext context, string mediaType)
     {
         return MediaTypesBrowserCanView.Contains(mediaType) || context.Request.AcceptTypes.Contains(mediaType);
     }

--- a/Website/Renderers/ShowMedia.ashx
+++ b/Website/Renderers/ShowMedia.ashx
@@ -205,7 +205,7 @@ public class ShowMedia : IHttpHandler, IReadOnlySessionState
         }
 
         bool download = (string.IsNullOrEmpty(context.Request["download"]) ?
-            !CabBePreviewedInBrowser(file.MimeType) :
+            !CabBePreviewedInBrowser(context, file.MimeType) :
             context.Request["download"] != "false");
 
         context.Response.AddHeader("Content-Disposition", "{0};filename=\"{1}\"".FormatWith((download ? "attachment" : "inline"), encodedFileName));
@@ -531,9 +531,9 @@ public class ShowMedia : IHttpHandler, IReadOnlySessionState
     }
 
 
-    private static bool CabBePreviewedInBrowser(string mediaType)
+    private static bool CabBePreviewedInBrowser(HttpContext context, string mediaType)
     {
-        return MediaTypesBrowserCanView.Contains(mediaType);
+        return MediaTypesBrowserCanView.Contains(mediaType) || context.Request.AcceptTypes.Contains(mediaType);
     }
 
 


### PR DESCRIPTION
Adding a new interface IImageFileFormatProvider, to enable support for new image formats.
Optimizing and rewriting parts of the ImageResizer class.
