### PR TITLE
Fix server error when using Text-control on null-properties

### DIFF
--- a/Website/Composite/controls/FormsControls/FormUiControlTemplates/Text/Text.ascx
+++ b/Website/Composite/controls/FormsControls/FormUiControlTemplates/Text/Text.ascx
@@ -7,7 +7,7 @@
     protected override void InitializeViewState(){}
 </script>
 
-<%= "<span>" + HttpUtility.HtmlEncode(this.Text).Replace("\n", "</span><br/><span>") + "</span>" %>
+<%= "<span>" + HttpUtility.HtmlEncode(this.Text ?? "").Replace("\n", "</span><br/><span>") + "</span>" %>
 
 
 


### PR DESCRIPTION
Fix server error when using Text-control on null-properties.

The same null check exists in LongText.ascx so we are adding it here to Text.ascx as well.