### PR TITLE
Allow longer URLs due to increased Product Display Name length

### DIFF
--- a/Website/DebugBuild.Web.config
+++ b/Website/DebugBuild.Web.config
@@ -29,7 +29,7 @@
     <httpHandlers>
       <add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
     </httpHandlers>
-    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
+    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" maxUrlLength="512" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
     <pages clientIDMode="AutoID">
       <controls>
         <add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />

--- a/Website/ReleaseBuild.Web.config
+++ b/Website/ReleaseBuild.Web.config
@@ -29,7 +29,7 @@
     <httpHandlers>
       <add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
     </httpHandlers>
-    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
+    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" maxUrlLength="512" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
     <pages clientIDMode="AutoID">
       <controls>
         <add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />


### PR DESCRIPTION
As we are now allowing up to 256 characters for Product Display Name, the Product Page URL length allowance needs to be increased.  The default value is 260, so a larger value is needed.
[maxUrlLength Reference](https://learn.microsoft.com/en-us/dotnet/api/system.web.configuration.httpruntimesection.maxurllength?view=netframework-4.8.1)

Not included in this PR, but we could consider changing Website\Composite\web.config
---Already has maxUrlLength="51200" which is extremely large

