### PR TITLE
Revert "Allow longer URLs due to increased Product Display Name length"

### DIFF
--- a/Website/DebugBuild.Web.config
+++ b/Website/DebugBuild.Web.config
@@ -29,7 +29,7 @@
     <httpHandlers>
       <add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
     </httpHandlers>
-    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" maxUrlLength="512" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
+    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
     <pages clientIDMode="AutoID">
       <controls>
         <add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />

--- a/Website/ReleaseBuild.Web.config
+++ b/Website/ReleaseBuild.Web.config
@@ -29,7 +29,7 @@
     <httpHandlers>
       <add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
     </httpHandlers>
-    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" maxUrlLength="512" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
+    <httpRuntime fcnMode="Single" targetFramework="4.8" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
     <pages clientIDMode="AutoID">
       <controls>
         <add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />


### PR DESCRIPTION
This reverts commit b9830235c0b99ee26ad57c463572d76e66008f08.  The change is not needed at the C1 level.