### PR TITLE
[Firefox] TinyMCE jumps to the top on function edit/add

### DIFF
--- a/Website/Frontend/Config/VisualEditor/Styles/core.css
+++ b/Website/Frontend/Config/VisualEditor/Styles/core.css
@@ -17,6 +17,11 @@ body {
 	padding: 22px 26px 30px 26px;
 	line-height: 20px;
 }
+/* Fix for a Firefox glitch that makes the page editor jump to the top every time you add or edit a function */
+body#tinymce {
+	height: auto;
+	min-height: 100%;
+}
 h1:first-child,
 h2:first-child,
 h3:first-child,
@@ -124,11 +129,12 @@ img.compositeFunctionWysiwygRepresentation.loaded{
     background-size: 8000px 60px;
     background-repeat: no-repeat;
     background-position: top right;
-    background-color: none;
+    background-color: transparent;
     width: auto; 
     min-height: 0;
     opacity: 1;
     cursor: default;
+	display: inline; /* Fix for Firefox. The "block" value makes the page editor almost unusable because it tries to add elements inside the [function] */
 }
 
 img.compositeFunctionWysiwygRepresentation.loaded:hover {


### PR DESCRIPTION
- In Firefox, the `height: 100%;` CSS rule on the TinyMCE `<body>` made the user jump to the top of the editor every time a C1 function was modified or added
- In Firefox, the `display:block;` CSS rule on the images representing C1 functions made it impossible to add something before or after an existing function in the Visual Editor. For example, when hitting the Enter key, TinyMCE tried to add the new `<div>` or `<p>` inside the `<function>` markup, which of course doesn't work...
- `background-color: none;` is invalid CSS... fixed it since I was playing around with those images CSS

Resolves: #80266