### PR TITLE
Remove unsupported WF  designer project type to enable VS2022 build

### DIFF
--- a/Composite.Workflows/Composite.Workflows.csproj
+++ b/Composite.Workflows/Composite.Workflows.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Composite</RootNamespace>
     <AssemblyName>Composite.Workflows</AssemblyName>
-    <ProjectTypeGuids>{14822709-B5A1-4724-98CA-57A101D1B079};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Composite</RootNamespace>
     <AssemblyName>Composite</AssemblyName>
-    <ProjectTypeGuids>{14822709-B5A1-4724-98CA-57A101D1B079};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>


### PR DESCRIPTION
Migrate build agent from Windows 2019 / VS 2019 to Windows 2025 / VS 2022.
 
 Windows 2019 with VS 2019 is no longer supported as a build target.
 
 Note: Editing existing workflow designer components (.designer.cs files) is
 disabled — the legacy Windows Workflow Foundation designer is not supported
 in VS 2022. These components can still be used at runtime, but cannot be
 visually edited.