### PR TITLE
Bug 85923: [C1 CMS: Content: Editor] Using the BACKSPACE and DELETE k…

### DIFF
--- a/Website/Composite/content/misc/editors/visualeditor/bindings/VisualEditorPageBinding.js
+++ b/Website/Composite/content/misc/editors/visualeditor/bindings/VisualEditorPageBinding.js
@@ -145,7 +145,18 @@ VisualEditorPageBinding.prototype.initializeComponent = function ( editor, engin
 		self.updateUndoBroadcasters ();
 		editor.checkForDirty ();
 	});
-	
+
+	/*
+	 * The editor triggers the dirty-check on the "keypress" event, which
+	 * does not fire for non-character keys such as Backspace and Delete.
+	 * As a result, removing content with these keys did not activate the
+	 * Save button. The "input" event fires for any content change (Backspace,
+	 * Delete, cut, paste, typing), so hook it to detect these edits.
+	 */
+	instance.on('input',  function () {
+		editor.checkForDirty ();
+	});
+
 	/*
 	 * Register content change handler to support undo-redo.
 	 */


### PR DESCRIPTION
…eys does not make / indicate a page unsaved ("dirty")

#AB85923 #845